### PR TITLE
#508 search for related term

### DIFF
--- a/src/app/pages/projects/projects.component.html
+++ b/src/app/pages/projects/projects.component.html
@@ -56,9 +56,9 @@
                     <button mat-stroked-button (click)="onRestrictSearch($event)" (keyup.enter)="onSubmit()">Use my keywords only</button>
                 </div>
                 <div class="terms">
-                    <div class="term" *ngFor="let semanticTerm of semanticTerms">
-                        {{semanticTerm}}
-                    </div>
+                    <ng-container *ngFor="let semanticTerm of semanticTerms" >
+                        <a href="#" (click)="$event.preventDefault();onClickRelatedTerm(semanticTerm)" class="ecl-tag term">{{semanticTerm}}</a>
+                    </ng-container>
                 </div>
             </div>
             <kohesio-ecl-form-group>

--- a/src/app/pages/projects/projects.component.scss
+++ b/src/app/pages/projects/projects.component.scss
@@ -478,6 +478,11 @@ mat-sidenav {
       margin: 3px;
       font-weight: bold;
       border-radius: 10px;
+      text-decoration: none;
+
+      &:hover {
+        background-color: #5299f0;
+      }
     }
   }
 

--- a/src/app/pages/projects/projects.component.ts
+++ b/src/app/pages/projects/projects.component.ts
@@ -423,6 +423,11 @@ export class ProjectsComponent implements AfterViewInit, OnDestroy {
           }
         }
 
+        onClickRelatedTerm(term: any) {
+          this.myForm.patchValue({ "keywords": term });
+          this.onSubmit();
+        }
+
         ngOnDestroy(): void {
           this.destroyed.next();
           this.destroyed.complete();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11196689/154661858-137601b8-69eb-4883-aca2-b2ffd5c6bb96.png)

- Using ECL tag
- Added some highlighting on mouseover
- The other query parameters are kept
- Clicking will do a search with semantic turned on, so clicking on a term doesn't restrict the search for only that keyword but does a semantic search as if the term was put into the field.
